### PR TITLE
Modified date/time output to correct YYYY-MM-DD hh:mm:ss format

### DIFF
--- a/M5Wigler/M5Wigler.ino
+++ b/M5Wigler/M5Wigler.ino
@@ -124,17 +124,17 @@ void lookForNetworks() {
         logFile.print(',');
         logFile.print(getEncryption(i));
         logFile.print(',');
-        logFile.print(tinyGPS.date.year());
-        logFile.print('-');
-        logFile.print(tinyGPS.date.month());
-        logFile.print('-');
-        logFile.print(tinyGPS.date.day());
+        
+        char formattedDate[10];
+        sprintf(formattedDate, "%d-%02d-%02d", tinyGPS.date.year(), tinyGPS.date.month(), tinyGPS.date.day());
+        logFile.print(formattedDate);
+        
         logFile.print(' ');
-        logFile.print(tinyGPS.time.hour());
-        logFile.print(':');
-        logFile.print(tinyGPS.time.minute());
-        logFile.print(':');
-        logFile.print(tinyGPS.time.second());
+        
+        char formattedTime[8];
+        sprintf(formattedTime, "%02d:%02d:%02d", tinyGPS.time.hour(), tinyGPS.time.minute(), tinyGPS.time.second());
+        logFile.print(formattedTime);
+        
         logFile.print(',');
         logFile.print(WiFi.channel(i));
         logFile.print(',');


### PR DESCRIPTION
I found that writing the month, day, hour, minute or second as a direct output from the TinyGPS++ date or time object resulted in some values having their leading 0 dropped. For example, 8 for August as opposed to the expected 08. 

I haven't tested this on an M5 directly, but I believe it should work regardless of the hardware :)